### PR TITLE
Add ruby dev for pg gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # About APK: https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper
 # Packages are here: https://pkgs.alpinelinux.org/packages
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # Install Ruby and necessary dependencies:
 # irb wouldn't run because rdoc was missing
 
-RUN apk add --clean ruby=3.3.6-r0 \
-  vim && \
-  ruby-dev && \
+RUN apk add --clean ruby \
+  vim \
+  ruby-dev \
+  build-base \
+  postgresql-dev && \
   gem install rdoc && \
   gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ FROM alpine:3.20
 # Install Ruby and necessary dependencies:
 # irb wouldn't run because rdoc was missing
 
-RUN apk add --clean ruby=3.3.3-r0 \
+RUN apk add --clean ruby=3.3.6-r0 \
   vim && \
+  ruby-dev && \
   gem install rdoc && \
   gem install bundler
 


### PR DESCRIPTION
This image to support apps that want to use the `pg` gem. 

`apk` packages added:
- `ruby-dev`
- `build-base`
- `postgresql-dev`

Also now using Alpine 3.21.

It builds locally and I can interact with this image.